### PR TITLE
loosen version constraint on stdlib to support v1

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -5,11 +5,11 @@ description = "A zero dependency cross platform Gleam package for reading enviro
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "lpil", repo = "envoy" }
 links = [
-  { title = "Website", href = "https://gleam.run" },
-  { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
+    { title = "Website", href = "https://gleam.run" },
+    { title = "Sponsor", href = "https://github.com/sponsors/lpil" },
 ]
 
 [dependencies]
-gleam_stdlib = "~> 0.34"
+gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,8 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.34" }
+gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }


### PR DESCRIPTION
Hi, the current version constraint on the stdlib doesn't allow use with v1. This updates it 
